### PR TITLE
feat(impact): add impact verification meta tag to head

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,8 +23,10 @@ const prompt = Prompt({
 export const metadata: Metadata = {
   title: "PayLinq",
   description: "Official Paylinq website",
+  other: {
+    'impact-site-verification': '61693c8a-2f1f-4473-b964-08c494e60c58',
+  },
 };
-
 export default function RootLayout({
   children,
 }: Readonly<{


### PR DESCRIPTION
As part of the initiative to leverage Impact (https://app.impact.com) we need to verify the website. I added a meta tag with the information needed.